### PR TITLE
[Hotfix] Exchange rust-xtensa repository.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN echo 'int main() {  printf("Hello world\n"); }' > test.c \
  && rm a.out test.c test.S
 
 # RUN git clone https://github.com/MabezDev/rust-xtensa.git
-ARG RUST_REF=xtensa-target
-RUN git clone -b ${RUST_REF} https://github.com/MabezDev/rust-xtensa.git \
+ARG RUST_REF="fix/register_calculation"
+RUN git clone -b ${RUST_REF} https://github.com/0ndorio/rust-xtensa.git \
  && mkdir /rust_build \
  && cd rust-xtensa \
  && ./configure --llvm-root="/llvm_build" --prefix="/rust_build" \


### PR DESCRIPTION
Right now it is not possible to compile libcore with the xtensa fork of the rust compiler (rev `bba6c06` MabezDev/rust-xtensa#2).

The reasons are some flaws inside the calculation of required registers to pass function arguments. These got triggered through a recent update of the `compiler_builtins` helper crate which is dynamically injected into the build process of libcore via crates.io.

As long as this is the case we must are required to use this fork which contains a bunch of fixes.

A pull request to review & merge these fixes is already open (MabezDev/rust-xtensa#3).

---

Btw. thanks for your great work to make this toolchain more usable :)