### PR TITLE
Reflect esp-sys api change in template repo

### DIFF
--- a/bindgen-project
+++ b/bindgen-project
@@ -13,7 +13,7 @@ for i in $(find "$IDF_PATH/components" -maxdepth 3 -name include); do
 	FLAGS+=" -I$i"
 done
 
-: ${BINDGEN_FLAGS:="--use-core --no-layout-tests"}
+: ${BINDGEN_FLAGS:="--use-core --no-layout-tests --ctypes-prefix=libc"}
 
 bindgen $BINDGEN_FLAGS --output esp32-sys/src/bindings.rs esp32-sys/src/bindings.h -- $FLAGS
 


### PR DESCRIPTION
This is the necessary template change to make ctron/rust-esp-template#1 work.