### PR TITLE
Reorganize Dockerfile and update scripts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,7 @@ ENV LIBCLANG_PATH="${LLVM_INSTALL_PATH}/lib"
 VOLUME "${PROJECT}"
 WORKDIR "${PROJECT}"
 
-COPY bindgen-project build-project create-project image-project xbuild-project /usr/local/bin/
+COPY bindgen-project build-project create-project image-project xbuild-project flash-project /usr/local/bin/
 COPY templates/ "${TEMPLATES}"
 
 CMD ["/usr/local/bin/build-project"]

--- a/README.md
+++ b/README.md
@@ -11,25 +11,26 @@ This is a container which can be used to build a Rust project for the ESP32.
 
 This container image provides a few tools which can be run like this:
 
-    docker run -ti -v $PWD:/build:z quay.io/ctron/rust-esp:latest
+    docker run -ti -v $PWD:/home/project:z quay.io/ctron/rust-esp:latest
 
 ### Volume mapping
 
-The `-v $PWD:/build:z` will map the current directory into the location `/build` inside the container.
-This is required so that the tools inside the container can work with the project.
+The `-v $PWD:/home/project:z` will map the current directory into the location
+`/home/project` inside the container. This is required so that the tools inside
+the container can work with the project.
 
 The `$PWD` part uses the current directory. This will only work in a Bourne like shell. You can replace
 this with the absolute path to your project instead.
 
 You can drop the `:z` suffix, if you don't have SElinux on the host system.
 
-All following example assue that you use `$PWD:/build:z`.
+All following example assue that you use `$PWD:/home/project:z`.
 
 ### Default command
 
 This will run the default command `build-project`. You can run other commands, e.g. `bash` like this:
 
-    docker run -ti -v $PWD:/build:z quay.io/ctron/rust-esp:latest bash
+    docker run -ti -v $PWD:/home/project:z quay.io/ctron/rust-esp:latest bash
 
 ### Labels
 
@@ -46,12 +47,12 @@ So should the `latest` image break, it should always be possible to switch to a 
 Initially a few files need to be set up. The ESP-IDF components need to be configured and compiled.
 Run the following command to create an initial setup:
 
-    docker run -ti -v $PWD:/build:z quay.io/ctron/rust-esp:latest create-project
+    docker run -ti -v $PWD:/home/project:z quay.io/ctron/rust-esp:latest create-project
 
 This will create (overwrite) as few files which are required to build the project.
 Next run:
 
-    docker run -ti -v $PWD:/build:z quay.io/ctron/rust-esp:latest make menuconfig
+    docker run -ti -v $PWD:/home/project:z quay.io/ctron/rust-esp:latest make menuconfig
 
 Which will start the ESP-IDF build and shows you the menu config tool for configuring
 your ESP project. Be sure to save when you exit.
@@ -60,15 +61,19 @@ your ESP project. Be sure to save when you exit.
 
 In order to build the project, run the following command:
 
-    docker run -ti -v $PWD:/build:z quay.io/ctron/rust-esp:latest
+    docker run -ti -v $PWD:/home/project:z quay.io/ctron/rust-esp:latest
 
 This will compile the ESP-IDF part, the rust part and finally convert it to an image
 which you can upload to your ESP.
 
 ## Uploading
 
-You can then upload the image using an `esptool` on any machnine. As it might be difficult to do this
-from inside the container, it is recommended to do this on the host system:
+You can then upload the image using the `flash-project` executable:
+
+    docker run -ti --device=/dev/ttyUSB0 -v $PWD:/home/project:z rust-esp32:latest flash-project
+
+If this doesn't work or you need to use differnt tool it might be easier to
+upload the image via `esptool` from the host machine. To do this call:
 
     esptool write_flash 0x10000 esp-app.bin
 
@@ -86,7 +91,7 @@ You can also build the container image yourself, by cloning this repository and 
   * A test on Windows shows that, yes it works. But with some quirks:
     * The menu `make menuconfig` renders a bit weird. Maybe the new Windows terminal will fix this.
     * The first `make app` will run just fine, but after that it fails to compile. Maybe some
-      issue with the Windows CIFS mapping in Docker. However, you can skip this step and run `xargo-project`
+      issue with the Windows CIFS mapping in Docker. However, you can skip this step and run `xbuild-project`
       instead. That will only compile the rust part.
   * In theory this should work also with with the ESP8266. A few tweaks for the build files
     will be required, and I didn't test this.

--- a/bindgen-project
+++ b/bindgen-project
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 FLAGS=""
-FLAGS+=" --sysroot=/esp/xtensa-esp32-elf/xtensa-esp32-elf/sysroot"
-FLAGS+=" -I/build/build/include"
+FLAGS+=" --sysroot=${ESP_PATH}/xtensa-esp32-elf/sysroot"
+FLAGS+=" -I${PROJECT}/build/include"
 FLAGS+=" -D__bindgen"
 FLAGS+=" -target xtensa"
 FLAGS+=" -x c"
 
-for i in $(find "$IDF_PATH/components" -maxdepth 3 -name include); do
-	FLAGS+=" -I$i"
-done
+while read -r include; do
+	FLAGS+=" -I${include}"
+done <<< "$(find "${IDF_PATH}/components" -maxdepth 3 -name include)"
 
-: ${BINDGEN_FLAGS:="--use-core --no-layout-tests"}
+: "${BINDGEN_FLAGS:=--use-core --no-layout-tests}"
 
+#shellcheck disable=SC2086
 bindgen $BINDGEN_FLAGS --output esp32-sys/src/bindings.rs esp32-sys/src/bindings.h -- $FLAGS
-

--- a/build-project
+++ b/build-project
@@ -4,7 +4,7 @@ set -e
 
 die() { echo "$*" 1>&2 ; exit 1 ; }
 
-test -f Cargo.toml || die "unable to find 'Cargo.toml'. You will need to map the container path /build to the path of your Rust project. You can do this using: docker run -ti -v $PWD:/build:z rust-esp"
+test -f Cargo.toml || die "unable to find 'Cargo.toml'. You will need to map the container path /home/build to the path of your Rust project. You can do this using: docker run -ti -v $PWD:/build:z rust-esp"
 
 for i in esp-idf .cargo main; do
 	test -d "$i" || die "'$i' is missing. Use 'create-project' to set up the build."
@@ -24,7 +24,7 @@ if test -d esp32-sys; then
 	fi
 fi
 
-xargo-project
+xbuild-project
 image-project
 
 echo Build complete

--- a/create-project
+++ b/create-project
@@ -4,20 +4,20 @@ set -e
 
 die() { echo "$*" 1>&2 ; exit 1 ; }
 
-test -f Cargo.toml || die "unable to find 'Cargo.toml'. You will need to map the container path /build to the path of your Rust project. You can do this using: docker run -ti -v $PWD:/build:z rust-esp"
+test -f Cargo.toml || die "unable to find 'Cargo.toml'. You will need to map the container path /build to the path of your Rust project. You can do this using: docker run -ti -v $PWD:/home/project/build:z rust-esp"
 
 echo "Creating Makefile (Makefile)"
-cp /templates/Makefile Makefile
+cp "${TEMPLATES}/Makefile" Makefile
 
 echo "Creating esp-idf symlink (esp-idf -> /esp-idf)"
-ln -sf /esp-idf esp-idf
+ln -sf "${IDF_PATH}" esp-idf
 
 echo "Creating cargo config (.cargo/config)"
 mkdir -p .cargo
-cp /templates/cargo.config .cargo/config
+cp "${TEMPLATES}/cargo.config" .cargo/config
 
 echo "Creating main application wrapper (main/esp_app_main.c)"
 mkdir -p main
-cp /templates/main.c main/esp_app_main.c
-cp /templates/component.mk main/
+cp "${TEMPLATES}/main.c" main/esp_app_main.c
+cp "${TEMPLATES}/component.mk" main/
 

--- a/flash-project
+++ b/flash-project
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+"$IDF_PATH/components/esptool_py/esptool/esptool.py" \
+     --chip esp32 \
+     --port /dev/ttyUSB0 \
+     --baud 115200 \
+     --before default_reset \
+     --after hard_reset \
+     write_flash \
+     -z \
+     --flash_mode dio \
+     --flash_freq 40m \
+     --flash_size detect \
+     0x1000 build/bootloader/bootloader.bin \
+     0x10000 build/esp-app.bin \
+     0x8000 build/partitions_singleapp.bin

--- a/image-project
+++ b/image-project
@@ -2,6 +2,10 @@
 
 set -e
 
-$IDF_PATH/components/esptool_py/esptool/esptool.py --chip esp32 elf2image -o esp-app.bin target/xtensa-esp32-none-elf/release/esp-app
+"${IDF_PATH}/components/esptool_py/esptool/esptool.py" \
+     --chip esp32 \
+     elf2image \
+     -o build/esp-app.bin \
+     target/xtensa-esp32-none-elf/release/esp-app
 
-echo "You can now flash 'esp-app.bin'"
+echo "You can now flash 'build/esp-app.bin'"

--- a/xargo-project
+++ b/xargo-project
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-rustup run xtensa xargo build --target ${XARGO_TARGET:-xtensa-esp32-none-elf} --release

--- a/xbuild-project
+++ b/xbuild-project
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release


### PR DESCRIPTION
As the xtensa-esp32-rust toolchain contains multiple components which all require their own setup the Dockerfile is rather large. To increase the maintainability I tried to reorganize the file a bit.

The updated Dockerfile should ...

  - expose the expected versions of the toolchain components,
  - add a bit more structure to the final container,
  - avoid to build and run the llvm tests
  - remove unnecessary intermediate artefacts before they
    are persisted,
  - and replace xargo which is in maintanence mode with cargo-xbuild.

To reflect these changes the scripts got updated as well and all shellcheck related warnings got fixed.
Also a new `flash-project` executable got added which can be used to flash the image to `/dev/ttyUSB0`.

---

Feel free to drop these changes / nitpick as much as you want. I will try to fix upcoming change requests asap.