### PR TITLE
More include file paths for bindgen

### DIFF
--- a/bindgen-project
+++ b/bindgen-project
@@ -13,6 +13,12 @@ while read -r include; do
 	FLAGS+=" -I${include}"
 done <<< "$(find "${IDF_PATH}/components" -maxdepth 3 -name include)"
 
+# Not picked up from above
+FLAGS+=" -I${IDF_PATH}/components/lwip/lwip/src/include"
+FLAGS+=" -I${IDF_PATH}/components/lwip/port/esp32/include"
+FLAGS+=" -I${IDF_PATH}/components/newlib/platform_include"
+FLAGS+=" -I${IDF_PATH}/components/lwip/include/apps"
+
 : "${BINDGEN_FLAGS:=--use-core --no-layout-tests}"
 
 #shellcheck disable=SC2086


### PR DESCRIPTION
This allows including things like `#include "esp_wifi.h"` in `bindings.h`

Just increasing the depth did not work well, since bindgen starts picking the wrong files due to file name collisions.