### PR TITLE
Store cargo artefacts in target/cargo to speed up rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ARG RUSTC_PATH="${RUSTC_BASE}/rust_xtensa"
 ARG RUSTC_BUILD_PATH="${RUSTC_BASE}/rust_build"
 
 ENV PATH "/root/.cargo/bin:${ESP_PATH}/bin:${PATH}"
+ENV CARGO_HOME /home/project/target/cargo
 
 # -------------------------------------------------------------------
 # Install expected depdendencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ ARG RUSTC_PATH="${RUSTC_BASE}/rust_xtensa"
 ARG RUSTC_BUILD_PATH="${RUSTC_BASE}/rust_build"
 
 ENV PATH "/root/.cargo/bin:${ESP_PATH}/bin:${PATH}"
-ENV CARGO_HOME /home/project/target/cargo
 
 # -------------------------------------------------------------------
 # Install expected depdendencies
@@ -155,6 +154,7 @@ ENV PROJECT="/home/project/"
 ENV XARGO_RUST_SRC="${RUSTC_PATH}/src"
 ENV TEMPLATES="${TOOLCHAIN}/templates"
 ENV LIBCLANG_PATH="${LLVM_INSTALL_PATH}/lib"
+ENV CARGO_HOME="${PROJECT}target/cargo"
 
 VOLUME "${PROJECT}"
 WORKDIR "${PROJECT}"

--- a/xbuild-project
+++ b/xbuild-project
@@ -2,4 +2,4 @@
 
 set -e
 
-CARGO_HOME=/home/project/target/cargo cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release
+cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release

--- a/xbuild-project
+++ b/xbuild-project
@@ -2,4 +2,4 @@
 
 set -e
 
-cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release
+CARGO_HOME=/home/project/target/cargo cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release


### PR DESCRIPTION
This avoids cargo downloading packages every build, since we can't cache anything in the docker container at runtime