### PR TITLE
Update rust-xtensa version to support stable rustc v1.37.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG CLANG_VERSION="248d9ce8765248d953c3e5ef4022fb350bbe6c51"
 ARG LLVM_VERSION="757e18f722dbdcd98b8479e25041b1eee1128ce9"
 
 # rust-xtensa
-ARG RUSTC_VERSION="8b4a5a9d98912e97d4d3178705bb2dc19f50d1cb"
+ARG RUSTC_VERSION="b365cff41a60df8fd5f1237ef71897edad0375dd"
 
 # -------------------------------------------------------------------
 # Toolchain Path Config


### PR DESCRIPTION
https://github.com/MabezDev/rust-xtensa/commit/b365cff41a60df8fd5f1237ef71897edad0375dd just updated the `rust-xtensa` fork to support the latest stable release (`v1.37`).

Even with the release of the official `v1.38` scheduled for next week it would be great if we could lift the container to support `1.37` as it is not clear when Mabez is going to update the fork again.

---

Supporting `v1.37` instead of the previous `v1.33` allows to use `extern crate alloc` without the nightly only `#[feature(allocator)]` attribute and therefore also all `no_std` compatible dependencies which do not use this flag anymore.