### PR TITLE
Forward command-line flags for build scripts

### DIFF
--- a/build-project
+++ b/build-project
@@ -24,7 +24,7 @@ if test -d esp32-sys; then
 	fi
 fi
 
-xbuild-project
+xbuild-project "$@"
 image-project
 
 echo Build complete

--- a/xbuild-project
+++ b/xbuild-project
@@ -2,4 +2,4 @@
 
 set -e
 
-cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release
+cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release "$@"


### PR DESCRIPTION
This change should be quite straight-forward, and it lets users run builds where they need to pass in cargo flags like `--features` etc.