### PR TITLE
Upgrade idf version to 4.0-beta2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ FROM debian:buster-slim
 # -------------------------------------------------------------------
 
 # esp-idf framework
-ARG IDF_VERSION="v4.0-beta2"
+ARG IDF_VERSION="v4.0"
 
 # llvm-xtensa
 ARG CLANG_VERSION="248d9ce8765248d953c3e5ef4022fb350bbe6c51"
 ARG LLVM_VERSION="757e18f722dbdcd98b8479e25041b1eee1128ce9"
 
 # rust-xtensa
-ARG RUSTC_VERSION="cf75e7f9a189657830a5619ce51a2891a618232c"
+ARG RUSTC_VERSION="2d3ec14f587789a9cab55597e376ea15d76fd75e"
 
 # -------------------------------------------------------------------
 # Toolchain Path Config
@@ -56,6 +56,7 @@ RUN apt-get update \
        pkg-config \
        python \
        python-pip \
+       python-virtualenv \
        wget \
  && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,15 @@ FROM debian:buster-slim
 # Toolchain Version Config
 # -------------------------------------------------------------------
 
-# Espressif toolchain
-ARG ESP_VERSION="1.22.0-80-g6c4433a-5.2.0"
-
 # esp-idf framework
-ARG IDF_VERSION="v3.3-beta3"
+ARG IDF_VERSION="v4.0-beta2"
 
 # llvm-xtensa
 ARG CLANG_VERSION="248d9ce8765248d953c3e5ef4022fb350bbe6c51"
 ARG LLVM_VERSION="757e18f722dbdcd98b8479e25041b1eee1128ce9"
 
 # rust-xtensa
-ARG RUSTC_VERSION="b365cff41a60df8fd5f1237ef71897edad0375dd"
+ARG RUSTC_VERSION="cf75e7f9a189657830a5619ce51a2891a618232c"
 
 # -------------------------------------------------------------------
 # Toolchain Path Config
@@ -24,7 +21,6 @@ ARG RUSTC_VERSION="b365cff41a60df8fd5f1237ef71897edad0375dd"
 ARG TOOLCHAIN="/home/esp32-toolchain"
 
 ARG ESP_BASE="${TOOLCHAIN}/esp"
-ENV ESP_PATH "${ESP_BASE}/esp-toolchain"
 ENV IDF_PATH "${ESP_BASE}/esp-idf"
 
 ARG LLVM_BASE="${TOOLCHAIN}/llvm"
@@ -36,7 +32,7 @@ ARG RUSTC_BASE="${TOOLCHAIN}/rustc"
 ARG RUSTC_PATH="${RUSTC_BASE}/rust_xtensa"
 ARG RUSTC_BUILD_PATH="${RUSTC_BASE}/rust_build"
 
-ENV PATH "/root/.cargo/bin:${ESP_PATH}/bin:${PATH}"
+ENV PATH "/root/.cargo/bin:${PATH}"
 
 # -------------------------------------------------------------------
 # Install expected depdendencies
@@ -53,27 +49,15 @@ RUN apt-get update \
        git \
        gperf \
        libncurses-dev \
+       libssl-dev \
+       libusb-1.0.0 \
        make \
        ninja-build \
+       pkg-config \
        python \
        python-pip \
        wget \
  && rm -rf /var/lib/apt/lists/*
-
-# -------------------------------------------------------------------
-# Setup esp32 toolchain
-# -------------------------------------------------------------------
-
-WORKDIR "${ESP_BASE}"
-RUN curl \
-       --proto '=https' \
-       --tlsv1.2 \
-       -sSf \
-       -o "${ESP_PATH}.tar.gz" \
-       "https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-${ESP_VERSION}.tar.gz" \
- && mkdir "${ESP_PATH}" \
- && tar -xzf "${ESP_PATH}.tar.gz" -C "${ESP_PATH}" --strip-components 1 \
- && rm -rf "${ESP_PATH}.tar.gz"
 
 # -------------------------------------------------------------------
 # Setup esp-idf
@@ -83,7 +67,8 @@ WORKDIR "${ESP_BASE}"
 RUN  git clone \
        --recursive --single-branch -b "${IDF_VERSION}" \
        https://github.com/espressif/esp-idf.git \
- && pip install --user -r "${IDF_PATH}/requirements.txt"
+ && cd "${IDF_PATH}" \
+ && ./install.sh
 
 # -------------------------------------------------------------------
 # Build llvm-xtensa

--- a/bindgen-project
+++ b/bindgen-project
@@ -18,6 +18,8 @@ FLAGS+=" -I${IDF_PATH}/components/lwip/lwip/src/include"
 FLAGS+=" -I${IDF_PATH}/components/lwip/port/esp32/include"
 FLAGS+=" -I${IDF_PATH}/components/newlib/platform_include"
 FLAGS+=" -I${IDF_PATH}/components/lwip/include/apps"
+FLAGS+=" -I${IDF_PATH}/components/lwip/include/apps/sntp"
+FLAGS+=" -I${IDF_PATH}/components/esp-tls"
 
 : "${BINDGEN_FLAGS:=--use-core --no-layout-tests}"
 

--- a/build-project
+++ b/build-project
@@ -2,6 +2,8 @@
 
 set -e
 
+source "$IDF_PATH/export.sh"
+
 die() { echo "$*" 1>&2 ; exit 1 ; }
 
 test -f Cargo.toml || die "unable to find 'Cargo.toml'. You will need to map the container path /home/project to the path of your Rust project. You can do this using: docker run -ti -v $PWD:/home/project:z rust-esp"

--- a/flash-project
+++ b/flash-project
@@ -2,6 +2,8 @@
 
 set -e
 
+source "$IDF_PATH/export.sh"
+
 "$IDF_PATH/components/esptool_py/esptool/esptool.py" \
      --chip esp32 \
      --port /dev/ttyUSB0 \

--- a/image-project
+++ b/image-project
@@ -2,6 +2,8 @@
 
 set -e
 
+source "$IDF_PATH/export.sh"
+
 "${IDF_PATH}/components/esptool_py/esptool/esptool.py" \
      --chip esp32 \
      elf2image \


### PR DESCRIPTION
This switches to the latest v4.0 branch of the IDF, which has a ton of new features and supports automatic toolchain management.