### PR TITLE
Determine link flags by interrogating the Makefile

### DIFF
--- a/flash-project
+++ b/flash-project
@@ -13,6 +13,5 @@ set -e
      --flash_mode dio \
      --flash_freq 40m \
      --flash_size detect \
-     0x1000 build/bootloader/bootloader.bin \
      0x10000 build/esp-app.bin \
      0x8000 build/partitions_singleapp.bin

--- a/templates/cargo.config
+++ b/templates/cargo.config
@@ -2,58 +2,9 @@
 target = "xtensa-esp32-none-elf"
 
 [target.xtensa-esp32-none-elf]
+linker = "rust-esp-linker"
 rustflags = [
   "-C", "target-cpu=esp32",
-  "-C", "save-temps",
-  "-C", "link-arg=-nostdlib",
-#  "-C", "link-arg=-nostartfiles",
-
-  "-C", "link-arg=-ucall_user_start_cpu0",
-  "-C", "link-arg=-u__cxa_guard_dummy",
-  "-C", "link-arg=-u__cxx_fatal_exception",
-  "-C", "link-arg=-uld_include_panic_highint_hdl",
-  "-C", "link-arg=-uesp_app_desc",
-
-  "-C", "link-arg=-Wl,--gc-sections",
-  "-C", "link-arg=-Wl,-static",
-  "-C", "link-arg=-Wl,--start-group",
-
-  "-C", "link-arg=-Lbuild/app_update", "-C", "link-arg=-lapp_update",
-  "-C", "link-arg=-Lbuild/driver", "-C", "link-arg=-ldriver",
-  "-C", "link-arg=-Lbuild/esp-tls",  "-C", "link-arg=-lesp-tls",
-  "-C", "link-arg=-Lbuild/esp32",  "-C", "link-arg=-lesp32",
-  "-C", "link-arg=esp-idf/components/esp32/libhal.a",
-  "-C", "link-arg=-Lesp-idf/components/esp32/lib", "-C", "link-arg=-lcore",
-
-  "-C", "link-arg=-Lesp-idf/components/esp32/ld",
-  "-C", "link-arg=-Tesp32_out.ld",
-  "-C", "link-arg=-Tbuild/esp32/esp32.project.ld",
-  "-C", "link-arg=-Tesp32.rom.ld",
-  "-C", "link-arg=-Tesp32.peripherals.ld",
-  "-C", "link-arg=-Tesp32.rom.libgcc.ld",
-  "-C", "link-arg=-Tesp32.rom.spiram_incompatible_fns.ld",
-
-  "-C", "link-arg=-Lbuild/esp_ringbuf", "-C", "link-arg=-lesp_ringbuf",
-  "-C", "link-arg=-Lbuild/freertos", "-C", "link-arg=-lfreertos",
-
-  "-C", "link-arg=-Wl,--undefined=uxTopUsedPriority",
-
-  "-C", "link-arg=-Lbuild/heap", "-C", "link-arg=-lheap",
-  "-C", "link-arg=-Lbuild/log", "-C", "link-arg=-llog",
-
-  "-C", "link-arg=esp-idf/components/newlib/lib/libc.a",
-  "-C", "link-arg=esp-idf/components/newlib/lib/libm.a",
-
-  "-C", "link-arg=-Lbuild/newlib", "-C", "link-arg=-lnewlib",
-  "-C", "link-arg=-Lbuild/pthread", "-C", "link-arg=-lpthread",
-  "-C", "link-arg=-Lbuild/soc", "-C", "link-arg=-lsoc",
-  "-C", "link-arg=-Lbuild/spi_flash", "-C", "link-arg=-lspi_flash",
-  "-C", "link-arg=-Lbuild/vfs", "-C", "link-arg=-lvfs",
-  "-C", "link-arg=-Lbuild/xtensa-debug-module", "-C", "link-arg=-lxtensa-debug-module",
-
-  "-C", "link-arg=-lgcc",
-  "-C", "link-arg=-lstdc++",
-  "-C", "link-arg=-lgcov",
-  "-C", "link-arg=-Wl,--end-group",
-  "-C", "link-arg=-Wl,-EL",
+  "-C", "save-temps"
 ]
+

--- a/xbuild-project
+++ b/xbuild-project
@@ -2,4 +2,16 @@
 
 set -e
 
+get_make_var() {
+  var=$1
+  mkfile=$(mktemp /home/project/build/linker-XXXXXXXXXX.mk)
+  cp /home/project/Makefile "$mkfile"
+  echo 'print-%: ; @echo get-make-var: $($*)' >> "$mkfile"
+  value=$(make "print-$var" -f "$mkfile" BUILD_DIR_BASE="/home/project/build" | grep -F 'get-make-var: ' | cut -d' ' -f2-)
+  echo "$value"
+}
+
+LDFLAGS="$(get_make_var LDFLAGS)"
+export RUSTFLAGS="-C target-cpu=esp32 -C save-temps $(echo "$LDFLAGS" | sed 's/[^ ]* */-C link-arg=&/g')"
+
 cargo +xtensa xbuild --target "${XARGO_TARGET:-xtensa-esp32-none-elf}" --release


### PR DESCRIPTION
The Makefile can be used to determine all of the ESP-specific link flags, and by injecting it through RUSTFLAGS, we don't need to keep a manual list in sync with the ESP IDF